### PR TITLE
Don't treat ignored patterns as regexps

### DIFF
--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -32,7 +32,7 @@ function add_patterns {
   local file="${1/#~/$HOME}"
   for pattern in "${@:2}"; do
     echo "... adding '$pattern'"
-    (test -f "$file" && test "$pattern" && grep -q -- "$pattern" "$file") || echo "$pattern" >> "$file"
+    (test -f "$file" && test "$pattern" && grep -q -F -x -- "$pattern" "$file") || echo "$pattern" >> "$file"
   done
 }
 


### PR DESCRIPTION
See issue #353 for details of the bug. This adds the `grep` arguments `-F` (to turn of regex processing) and `-x` (to turn off substring matching) when checking for duplicate entries in _.gitignore_. Both are POSIX arguments, so should be portable.
